### PR TITLE
Added visible functions for MapInputWidget object

### DIFF
--- a/sources/web/js/map-input-widget.js
+++ b/sources/web/js/map-input-widget.js
@@ -335,6 +335,17 @@ function MapInputWidget ( widget )
         map.setZoom(zoom);
     };
 
+    // Resize the map
+    this.resize = function()
+    {
+        google.maps.event.trigger(map, "resize");
+    };
+
+    // Gets the initial point
+    this.getInitialPoint = function ()
+    {
+        return getInitialValue();
+    };
 
 };
 
@@ -342,9 +353,7 @@ function MapInputWidget ( widget )
 // Use it to get references to widget instances.
 var mapInputWidgetManager;
 
-$(window).load
-(
-    function()
+$(window).on('load', function()
     {
 
         // Create an instance of widget manager


### PR DESCRIPTION
Added resize() and getInitialPoint() as visible functions for the MapInputWidget object .
These may be useful in the scenario when the map is initially in a hidden div, so the map has "width: 0", and when the div becomes visible is needed to trigger "resize" for the map.
So when the div becomes visible, a possible solution could be adding this lines to the event Listener:
var widgetMap = mapInputWidgetManager.getWidget(mapDiv.prop('id'));
if(mapDiv.is(':visible') && !mapDiv.data('resized')){
    widgetMap.resize();
    var point = widgetMap.getInitialPoint();
    /* for edit form */
    if(point){
        widgetMap.panTo(point);
        widgetMap.setZoom(15);
    }
    mapDiv.data('resized', true);
}