### PR TITLE
Move asset options to asset manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,32 @@ echo $form->field($model, 'coordinates')->widget('kolyunya\yii2\widgets\MapInput
 ~~~
 
 ### Extended example
+To configure asset manager use the following configuration
+
+~~~php
+return [
+    // ...
+    'components' => [
+        'assetManager' => [
+            'bundles' => [
+                \kolyunya\yii2\assets\MapInputAsset::class => [
+                    'options' => [
+                        'key' => 'YOUR_GOOGLE_MAPS_API_KEY',
+                        'language' => 'en',
+                        'libraries' => 'places',
+                    ],
+                ],
+            ],
+        ],
+    ],
+];
+~~~
+
 An exhaustive list of widget parameters (which are not derived from [yii\widgets\InputWidget](http://www.yiiframework.com/doc-2.0/yii-widgets-inputwidget.html)) available for configuration is described in the following example.
 ~~~php
 echo $form->field($model, 'coordinates')->widget(
     'kolyunya\yii2\widgets\MapInputWidget',
     [
-
-        // Google maps browser key.
-        'key' => $key,
-
         // Initial map center latitude. Used only when the input has no value.
         // Otherwise the input value latitude will be used as map center.
         // Defaults to 0.

--- a/sources/assets/MapInputAsset.php
+++ b/sources/assets/MapInputAsset.php
@@ -2,11 +2,35 @@
 
 namespace kolyunya\yii2\assets;
 
+/**
+ * Class MapInputAsset
+ *
+ * To configure asset manager use the following configuration
+ *
+ * return [
+ *     // ...
+ *     'components' => [
+ *         'assetManager' => [
+ *             'bundles' => [
+ *                 \kolyunya\yii2\assets\MapInputAsset::class => [
+ *                     'options' => [
+ *                         'key' => 'YOUR_GOOGLE_MAPS_API_KEY',
+ *                         'language' => 'en',
+ *                         'libraries' => 'places',
+ *                     ],
+ *                 ],
+ *             ],
+ *         ],
+ *     ],
+ * ];
+ *
+ * http://www.yiiframework.com/doc-2.0/guide-structure-assets.html#customizing-asset-bundles
+ *
+ * @package kolyunya\yii2\assets
+ */
+
 class MapInputAsset extends \yii\web\AssetBundle
 {
-
-    public static $key;
-
     public $sourcePath = '@kolyunya/yii2-map-input-widget/sources/web';
 
     public $depends =
@@ -19,9 +43,16 @@ class MapInputAsset extends \yii\web\AssetBundle
         'position' => \yii\web\View::POS_END,
     ];
 
-    public function __construct($config = [])
+    /** @var array */
+    public $options = [];
+
+    /**
+     * @return void
+     */
+    public function init()
     {
-        $this->js[] = $this->getGoogleMapScriptUrl();
+        $this->js[] = '//maps.googleapis.com/maps/api/js?' . http_build_query($this->options);
+
         if (YII_DEBUG) {
             $this->js[] = 'js/map-input-widget.js';
             $this->css[] = 'css/map-input-widget.css';
@@ -29,16 +60,5 @@ class MapInputAsset extends \yii\web\AssetBundle
             $this->js[] = 'js/map-input-widget.min.js';
             $this->css[] = 'css/map-input-widget.min.css';
         }
-        parent::__construct($config);
-    }
-
-    private function getGoogleMapScriptUrl()
-    {
-        $scriptUrl  =  "//maps.googleapis.com/maps/api/js?";
-        $scriptUrl .= http_build_query([
-            'key' => self::$key,
-            'libraries' => 'places',
-        ]);
-        return $scriptUrl;
     }
 }

--- a/sources/widgets/MapInputWidget.php
+++ b/sources/widgets/MapInputWidget.php
@@ -6,9 +6,6 @@ use Yii;
 
 class MapInputWidget extends \yii\widgets\InputWidget
 {
-
-    public $key;
-
     public $latitude = 0;
 
     public $longitude = 0;
@@ -31,11 +28,7 @@ class MapInputWidget extends \yii\widgets\InputWidget
 
     public function run()
     {
-
         Yii::setAlias('@kolyunya','@vendor/kolyunya');
-
-        // Asset bundle should be configured with the application key
-        $this->configureAssetBundle();
 
         return $this->render(
             'MapInputWidget',
@@ -55,10 +48,5 @@ class MapInputWidget extends \yii\widgets\InputWidget
                 'enableSearchBar' => $this->enableSearchBar,
             ]
         );
-    }
-
-    private function configureAssetBundle()
-    {
-        \kolyunya\yii2\assets\MapInputAsset::$key = $this->key;
     }
 }


### PR DESCRIPTION
This PR changes MapInputAsset configuration. Now it is being set via Yii2 assetManager setting in the configuration.
So now there is no need to pass Google API key to Widget and then to MapInputAsset. 
MapInputAsset is being configured on init. And configuration for MapInputAsset will be placed only in configuration files. 